### PR TITLE
Update for VKC-Kiminaze client.lua

### DIFF
--- a/client.lua
+++ b/client.lua
@@ -3,7 +3,7 @@ local vehicles = {}; RPWorking = true
 Citizen.CreateThread(function()
 	while true do
 		Citizen.Wait(0)
-		if Config.UseKey and Config.ToggleKey then
+		if Config.UseKey and Config.ToggleKey and IsPedInAnyVehicle (PlayerPedId ()) and (GetVehiclePedIsIn(PlayerPedId() == PlayerPedId())) then
 			if IsControlJustReleased(1, Config.ToggleKey) then
 				TriggerEvent('EngineToggle:Engine')
 			end


### PR DESCRIPTION
Update for VKC - by Kiminaze
Check for Engine Toggle Key, in Vehicle, to get rid of an Client Error.

> SCRIPT ERROR: Parameter "vehicle" was nil or vehicle does not exist!
(@EngineToggle/client.lua:50)
citizen:/scripting/lua/scheduler.lua:841: An error occurred while calling export IsVehicleOrKeyOwner of resource VehicleKeyChain

Will be fixed